### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Capsule enables apps to easily and securely bring users onchain with social sign
 [Capsule Wallet Demo](http://demo.beta.usecapsule.com/)\
 [Capsule Wallet](http://usecapsule.com/)
 #### Switchboard Oracle:
-Switchboard is a pull based oracle platform enabling builders to tailor hi-fidelity and exotic data feeds for their dApps while simultaneously composing with data feeds from Pyth and Chainlink. With Switchboard you can can build oracles and publish data feeds that service your exact needs. Checkout the resources below to learn more.\
+Switchboard is a pull based oracle platform enabling builders to tailor hi-fidelity and exotic data feeds for their dApps while simultaneously composing with data feeds from Pyth and Chainlink. With Switchboard you can build oracles and publish data feeds that service your exact needs. Checkout the resources below to learn more.\
 [Getting Started with Switchboard for EVM](https://docs.switchboard.xyz/docs/switchboard/switchboard-on-evm)\
 [Switchboard Example Repo](https://github.com/switchboard-xyz/evm-on-demand)
 #### thirdweb:


### PR DESCRIPTION

<img width="1236" alt="Снимок экрана 2024-11-10 в 15 33 35" src="https://github.com/user-attachments/assets/75c178af-65c4-440b-880c-4c6140a4dd22">


The word "can **can**" is repeated.
Corrected.