### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Community suggested resources for development on Monad.
 ### Solidity Development
 [Solidity Bootcamp by RareSkills](https://www.rareskills.io/solidity-bootcamp)\
 [Solidity Patterns](https://fravoll.github.io/solidity-patterns/)\
-[Cookbook.dev](cookbook.dev)\
+[Cookbook.dev](https://www.cookbook.dev/)\
 [Smart Contract Engineer](https://www.youtube.com/@smartcontractprogrammer)
 
 ### Web/Client Side Development


### PR DESCRIPTION
**Description:**  
This pull request fixes an issue in the "Solidity Development" section where the link for Cookbook.dev is missing the `https://` protocol.  

### Problem  
The link for Cookbook.dev was written as:  
```  
[Cookbook.dev](cookbook.dev)  
```  
This is incorrect because the protocol `https://` was omitted. Without the protocol, some browsers may not recognize the link properly, leading to broken or failed navigation.  

### Fix  
The corrected link is:  
```  
[Cookbook.dev](https://cookbook.dev)  
```  

### Importance  
- **Usability:** Ensures the link works as expected, improving the user experience.  
- **Consistency:** Aligns the link format with other correctly structured links throughout the document.  
- **Functionality:** Prevents potential issues with broken links when clicked, providing users with direct access to the resource.

Please review and merge.