### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Capsule enables apps to easily and securely bring users onchain with social sign
 [Capsule Wallet Demo](http://demo.beta.usecapsule.com/)\
 [Capsule Wallet](http://usecapsule.com/)
 #### Switchboard Oracle:
-Switchboard is a pull based oracle platform enabling builders to tailor hi-fidelity and exotic data feeds for their dApps while simultaneously composing with data feeds from Pyth and Chainlink. With Switchboard you can can build oracles and publish data feeds that service your exact needs. Checkout the resources below to learn more.\
+Switchboard is a pull based oracle platform enabling builders to tailor hi-fidelity and exotic data feeds for their dApps while simultaneously composing with data feeds from Pyth and Chainlink. With Switchboard you can build oracles and publish data feeds that service your exact needs. Checkout the resources below to learn more.\
 [Getting Started with Switchboard for EVM](https://docs.switchboard.xyz/docs/switchboard/switchboard-on-evm)\
 [Switchboard Example Repo](https://github.com/switchboard-xyz/evm-on-demand)
 #### thirdweb:


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `you can can build` to `you can build`

Please review the changes and let me know if any additional changes are needed.