### PR TITLE
fix: Incorrect Link Formatting Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,6 @@ Biconomy provides Account Abstraction APIs for a wide range of uses cases and po
 [Biconomy Documentation](https://docs.biconomy.io/)
 #### Wallet Connect (Reown):
 Wallet Connect is an easy way to get started with wallet integration across web3.\
-[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-appshttps://t.me/appkit_test_ggr_bot)\
+[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-apps)
+[AppKit Test Bot](https://t.me/appkit_test_ggr_bot)\
 [Reown Docs](https://docs.reown.com/)


### PR DESCRIPTION
### Description:  
This update addresses a formatting issue in the **Wallet Connect (Reown)** section, where a link to "Wallet Connect for Telegram Mini Apps" was incorrectly concatenated with another URL. The flawed link made it difficult for users to access the intended resources.

**Previous Link:**
```
https://docs.reown.com/appkit/features/telegram-mini-appshttps://t.me/appkit_test_ggr_bot
```

**Corrected Links:**
1. [[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-apps)](https://docs.reown.com/appkit/features/telegram-mini-apps)  
2. [[AppKit Test Bot](https://t.me/appkit_test_ggr_bot)](https://t.me/appkit_test_ggr_bot)  

### Importance:  
This fix ensures that users can easily navigate to the correct documentation and testing resources, improving the user experience and reducing potential confusion when working with Wallet Connect and related tools. Accurate links are critical for developers relying on these resources for their projects.